### PR TITLE
Fix module import scope conflicts and install issues

### DIFF
--- a/bin/win-ops.ps1
+++ b/bin/win-ops.ps1
@@ -17,9 +17,6 @@
 .PARAMETER Force
     Force execution without confirmation prompts
 
-.PARAMETER Verbose
-    Enable verbose output
-
 .EXAMPLE
     win-ops.ps1 help
     Display help information
@@ -54,7 +51,7 @@ param(
 
     [Parameter()]
     [Alias('v')]
-    [switch]$Verbose
+    [switch]$VerboseOutput
 )
 
 #Requires -Version 7.0
@@ -67,7 +64,7 @@ $script:ModuleVersion = '1.0.0'
 $script:ModuleName = 'win-ops'
 
 # Set verbose preference if flag is provided
-if ($Verbose) {
+if ($VerboseOutput) {
     $VerbosePreference = 'Continue'
 }
 
@@ -272,14 +269,14 @@ function Start-WinOpsCleanup {
         foreach ($module in $coreModules) {
             $modulePath = Join-Path $script:ScriptRoot $module
             if (Test-Path $modulePath) {
-                Import-Module $modulePath -Force
+                Import-Module $modulePath -Force -Global
             }
         }
 
         # Import Analyze module
         $analyzeModule = Join-Path $script:ScriptRoot 'lib\modules\Analyze.psm1'
         if (Test-Path $analyzeModule) {
-            Import-Module $analyzeModule -Force
+            Import-Module $analyzeModule -Force -Global
         }
 
         # Initialize logger
@@ -802,7 +799,7 @@ function Invoke-WinOps {
 
 # Main execution
 try {
-    Invoke-WinOps -Command $Command -DryRun:$DryRun -Force:$Force -Verbose:$Verbose
+    Invoke-WinOps -Command $Command -DryRun:$DryRun -Force:$Force
     exit 0
 }
 catch {

--- a/install.ps1
+++ b/install.ps1
@@ -234,6 +234,7 @@ $directories = @(
     'lib\utils',
     'config',
     'scheduler',
+    'resources',
     'logs'
 )
 
@@ -283,6 +284,15 @@ try {
     Get-ChildItem -Path (Join-Path $sourcePath 'scheduler') | ForEach-Object {
         Copy-Item -Path $_.FullName -Destination (Join-Path $InstallPath 'scheduler') -Force
         Write-Verbose "Copied: scheduler\$($_.Name)"
+    }
+
+    # Copy resources (i18n language files)
+    $resourcesSource = Join-Path $sourcePath 'resources'
+    if (Test-Path $resourcesSource) {
+        Get-ChildItem -Path $resourcesSource -Filter '*.json' | ForEach-Object {
+            Copy-Item -Path $_.FullName -Destination (Join-Path $InstallPath 'resources') -Force
+            Write-Verbose "Copied: resources\$($_.Name)"
+        }
     }
 
     # Copy module manifest

--- a/lib/modules/Analyze.psm1
+++ b/lib/modules/Analyze.psm1
@@ -21,14 +21,18 @@
 using namespace System.IO
 using namespace System.Collections.Generic
 
-# Import required core modules
+# Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
+if (-not (Get-Command Get-WinOpsConfig -ErrorAction SilentlyContinue)) {
+    Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
+}
+if (-not (Get-Command Initialize-WinOpsLogger -ErrorAction SilentlyContinue)) {
+    Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
+}
 
 # Import format module for visual output
 $utilsModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\utils'
-if (Test-Path (Join-Path $utilsModulePath 'Format.psm1')) {
+if ((Test-Path (Join-Path $utilsModulePath 'Format.psm1')) -and -not (Get-Command Format-WinOpsSize -ErrorAction SilentlyContinue)) {
     Import-Module (Join-Path $utilsModulePath 'Format.psm1') -Force -ErrorAction SilentlyContinue
 }
 

--- a/lib/modules/BrowserCleanup.psm1
+++ b/lib/modules/BrowserCleanup.psm1
@@ -21,12 +21,12 @@
 
 using namespace System.IO
 
-# Import required core modules
+# Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
 
 #region Browser Definitions
 

--- a/lib/modules/CacheCleanup.psm1
+++ b/lib/modules/CacheCleanup.psm1
@@ -22,12 +22,12 @@
 
 using namespace System.IO
 
-# Import required core modules
+# Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
 
 # Import I18n module
 $i18nModulePath = Join-Path $coreModulePath 'I18n.psm1'

--- a/lib/modules/DevCleanup.psm1
+++ b/lib/modules/DevCleanup.psm1
@@ -17,12 +17,12 @@
 
 using namespace System.IO
 
-# Import required core modules
+# Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
 
 #region Cache Target Definitions
 

--- a/lib/modules/DockerCleanup.psm1
+++ b/lib/modules/DockerCleanup.psm1
@@ -19,11 +19,11 @@
     Requires: Docker Desktop installed
 #>
 
-# Import required core modules
+# Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
 
 #region Private Functions
 

--- a/lib/modules/LogCleanup.psm1
+++ b/lib/modules/LogCleanup.psm1
@@ -21,12 +21,12 @@
 using namespace System.IO
 using namespace System.Diagnostics.Eventing.Reader
 
-# Import required core modules
+# Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
 
 #region Log Locations
 

--- a/lib/modules/OrphanAppCleanup.psm1
+++ b/lib/modules/OrphanAppCleanup.psm1
@@ -20,12 +20,12 @@
 
 using namespace System.IO
 
-# Import required core modules
+# Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
 
 #region Private Functions
 

--- a/lib/modules/OrphanKiller.psm1
+++ b/lib/modules/OrphanKiller.psm1
@@ -17,11 +17,11 @@
     Requires: Core modules (Config, Logger, Safety)
 #>
 
-# Import required core modules
+# Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
 
 #region Private Functions
 

--- a/lib/modules/PackageManagerCleanup.psm1
+++ b/lib/modules/PackageManagerCleanup.psm1
@@ -19,12 +19,12 @@
 
 using namespace System.IO
 
-# Import required core modules
+# Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
 
 #region Package Manager Locations
 

--- a/lib/modules/TmpCleanup.psm1
+++ b/lib/modules/TmpCleanup.psm1
@@ -21,12 +21,12 @@
 
 using namespace System.IO
 
-# Import required core modules
+# Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
 
 #region Temp Locations
 

--- a/lib/modules/ZombieKiller.psm1
+++ b/lib/modules/ZombieKiller.psm1
@@ -17,11 +17,11 @@
     Requires: Core modules (Config, Logger, Safety)
 #>
 
-# Import required core modules
+# Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
-Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
 
 #region Private Functions
 


### PR DESCRIPTION
## Summary
- Fix duplicate `-Verbose` parameter in `bin/win-ops.ps1` (`[CmdletBinding()]` already provides it) — renamed to `-VerboseOutput`
- Add `resources/` directory (i18n language files) copy step to `install.ps1` so localized messages work after installation
- Guard all cleanup module imports with `Get-Module` checks to prevent `Import-Module -Force` from removing previously loaded modules from the caller's scope

## Root Cause
Cleanup modules (Analyze, CacheCleanup, etc.) each did `Import-Module Logger.psm1 -Force` at the top level. When `bin/win-ops.ps1` imported Logger first, then imported a cleanup module, the `-Force` flag caused Logger to be unloaded from the caller's scope and reloaded into the cleanup module's scope. This made `Initialize-WinOpsLogger` unrecognizable at runtime.

## Test plan
- [x] `win-ops version` works after install
- [x] `win-ops help` displays correctly with i18n messages
- [x] `win-ops run -DryRun` no longer throws `Initialize-WinOpsLogger not recognized` error
- [ ] Full test suite (`Run-Tests.ps1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)