### PR TITLE
Add PowerShell 5.1 compatibility support

### DIFF
--- a/Run-Tests.ps1
+++ b/Run-Tests.ps1
@@ -67,12 +67,12 @@ if (-not $ScriptRoot) {
 }
 
 # Import Pester
-Write-Host "🔍 Checking Pester installation..." -ForegroundColor Cyan
+Write-Host "[SEARCH] Checking Pester installation..." -ForegroundColor Cyan
 
 $pesterModule = Get-Module -ListAvailable -Name Pester | Sort-Object Version -Descending | Select-Object -First 1
 
 if (-not $pesterModule) {
-    Write-Host "❌ Pester not found. Installing Pester 5.x..." -ForegroundColor Yellow
+    Write-Host "[FAIL] Pester not found. Installing Pester 5.x..." -ForegroundColor Yellow
     Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
     $pesterModule = Get-Module -ListAvailable -Name Pester | Sort-Object Version -Descending | Select-Object -First 1
 }
@@ -85,13 +85,13 @@ if ($pesterModule.Version.Major -lt 5) {
 
 Import-Module Pester -MinimumVersion 5.0.0 -ErrorAction Stop
 
-Write-Host "✅ Using Pester $($pesterModule.Version)" -ForegroundColor Green
+Write-Host "[OK] Using Pester $($pesterModule.Version)" -ForegroundColor Green
 
 #endregion
 
 #region Build Configuration
 
-Write-Host "📋 Building Pester configuration..." -ForegroundColor Cyan
+Write-Host "[LIST] Building Pester configuration..." -ForegroundColor Cyan
 
 $pesterConfig = New-PesterConfiguration
 
@@ -148,7 +148,7 @@ else {
 # Parallel execution
 if ($Parallel) {
     $pesterConfig.Run.Container = New-PesterContainer -Path $pesterConfig.Run.Path
-    Write-Host "⚡ Parallel execution enabled (experimental)" -ForegroundColor Cyan
+    Write-Host "* Parallel execution enabled (experimental)" -ForegroundColor Cyan
 }
 
 # Should settings
@@ -162,8 +162,8 @@ $pesterConfig.TestDrive.Enabled = $true
 #region Execute Tests
 
 Write-Host ""
-Write-Host "🧪 Running win-ops Tests" -ForegroundColor Cyan
-Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host "[TEST] Running win-ops Tests" -ForegroundColor Cyan
+Write-Host "===========================================================" -ForegroundColor Cyan
 Write-Host "  Path:        $($pesterConfig.Run.Path)" -ForegroundColor White
 Write-Host "  Coverage:    $(if ($pesterConfig.CodeCoverage.Enabled) { 'Enabled' } else { 'Disabled' })" -ForegroundColor White
 Write-Host "  Parallel:    $(if ($Parallel) { 'Enabled' } else { 'Disabled' })" -ForegroundColor White
@@ -173,7 +173,7 @@ if ($Tags) {
 if ($ExcludeTags) {
     Write-Host "  Exclude:     $($ExcludeTags -join ', ')" -ForegroundColor White
 }
-Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host "===========================================================" -ForegroundColor Cyan
 Write-Host ""
 
 $startTime = Get-Date
@@ -182,7 +182,7 @@ try {
     $results = Invoke-Pester -Configuration $pesterConfig
 }
 catch {
-    Write-Host "❌ Test execution failed: $_" -ForegroundColor Red
+    Write-Host "[FAIL] Test execution failed: $_" -ForegroundColor Red
     exit 1
 }
 
@@ -193,8 +193,8 @@ $duration = (Get-Date) - $startTime
 #region Report Results
 
 Write-Host ""
-Write-Host "📊 Test Results Summary" -ForegroundColor Cyan
-Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host "[STATS] Test Results Summary" -ForegroundColor Cyan
+Write-Host "===========================================================" -ForegroundColor Cyan
 
 # Test statistics
 $totalTests = $results.TotalCount
@@ -222,8 +222,8 @@ Write-Host "  Duration:    $($duration.TotalSeconds.ToString('F2')) seconds" -Fo
 # Code coverage
 if ($pesterConfig.CodeCoverage.Enabled -and $results.CodeCoverage) {
     Write-Host ""
-    Write-Host "📈 Code Coverage" -ForegroundColor Cyan
-    Write-Host "───────────────────────────────────────────────────────────" -ForegroundColor Cyan
+    Write-Host "[COV] Code Coverage" -ForegroundColor Cyan
+    Write-Host "-----------------------------------------------------------" -ForegroundColor Cyan
 
     $coverage = $results.CodeCoverage
     $commandsAnalyzed = $coverage.CommandsAnalyzedCount
@@ -243,7 +243,7 @@ if ($pesterConfig.CodeCoverage.Enabled -and $results.CodeCoverage) {
 
         $targetPercent = [double]$pesterConfig.CodeCoverage.CoveragePercentTarget.Value
         if ($coveragePercent -lt $targetPercent) {
-            Write-Host "  ⚠️  Coverage below target ($targetPercent%)" -ForegroundColor Yellow
+            Write-Host "  [WARN]  Coverage below target ($targetPercent%)" -ForegroundColor Yellow
         }
 
         Write-Host ""
@@ -256,7 +256,7 @@ if ($pesterConfig.TestResult.Enabled) {
     Write-Host "  Test results:    $($pesterConfig.TestResult.OutputPath)" -ForegroundColor Gray
 }
 
-Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host "===========================================================" -ForegroundColor Cyan
 
 #endregion
 
@@ -264,11 +264,11 @@ Write-Host "══════════════════════�
 
 if ($failedTests -gt 0) {
     Write-Host ""
-    Write-Host "❌ Failed Tests" -ForegroundColor Red
-    Write-Host "───────────────────────────────────────────────────────────" -ForegroundColor Red
+    Write-Host "[FAIL] Failed Tests" -ForegroundColor Red
+    Write-Host "-----------------------------------------------------------" -ForegroundColor Red
 
     foreach ($test in $results.Failed) {
-        Write-Host "  • $($test.ExpandedName)" -ForegroundColor Red
+        Write-Host "  * $($test.ExpandedName)" -ForegroundColor Red
         if ($test.ErrorRecord) {
             Write-Host "    $($test.ErrorRecord.Exception.Message)" -ForegroundColor Gray
         }
@@ -286,11 +286,11 @@ if ($PassThru) {
 }
 
 if ($failedTests -gt 0) {
-    Write-Host "❌ Tests FAILED" -ForegroundColor Red
+    Write-Host "[FAIL] Tests FAILED" -ForegroundColor Red
     exit 1
 }
 else {
-    Write-Host "✅ All tests PASSED" -ForegroundColor Green
+    Write-Host "[OK] All tests PASSED" -ForegroundColor Green
     exit 0
 }
 

--- a/bin/win-ops.ps1
+++ b/bin/win-ops.ps1
@@ -54,7 +54,7 @@ param(
     [switch]$VerboseOutput
 )
 
-#Requires -Version 7.0
+#Requires -Version 5.1
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -303,7 +303,7 @@ function Start-WinOpsCleanup {
 
         try {
             Write-Host "`n$(Get-WinOpsMessage -Key 'Cleanup_Title')" -ForegroundColor Cyan
-            Write-Host "═══════════════`n" -ForegroundColor Cyan
+            Write-Host "===============`n" -ForegroundColor Cyan
 
             if ($DryRun) {
                 Write-Host "$(Get-WinOpsMessage -Key 'Cleanup_DryRunMode')`n" -ForegroundColor Yellow
@@ -407,13 +407,13 @@ function Get-WinOpsStatus {
         if (Test-Path $lockModule) { Import-Module $lockModule -Force }
 
         Write-Host ""
-        Write-Host "╔══════════════════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-        Write-Host "║                          $(Get-WinOpsMessage -Key 'Status_Title')                                  ║" -ForegroundColor Cyan
-        Write-Host "╚══════════════════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
+        Write-Host "|                          $(Get-WinOpsMessage -Key 'Status_Title')                                  |" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
         Write-Host ""
 
         # System status
-        Write-Host "═══ $(Get-WinOpsMessage -Key 'Status_System') ═══" -ForegroundColor Cyan
+        Write-Host "=== $(Get-WinOpsMessage -Key 'Status_System') ===" -ForegroundColor Cyan
         Write-Host ""
 
         # Lock status
@@ -427,7 +427,7 @@ function Get-WinOpsStatus {
 
         # Disk usage
         Write-Host ""
-        Write-Host "═══ $(Get-WinOpsMessage -Key 'Status_DiskUsage') ═══" -ForegroundColor Cyan
+        Write-Host "=== $(Get-WinOpsMessage -Key 'Status_DiskUsage') ===" -ForegroundColor Cyan
         Write-Host ""
 
         $disks = Get-WinOpsDiskUsage -ExcludeNetworkDrives -ExcludeRemovableDrives
@@ -450,7 +450,7 @@ function Get-WinOpsStatus {
         }
 
         # Trash status
-        Write-Host "═══ $(Get-WinOpsMessage -Key 'Status_TrashStatus') ═══" -ForegroundColor Cyan
+        Write-Host "=== $(Get-WinOpsMessage -Key 'Status_TrashStatus') ===" -ForegroundColor Cyan
         Write-Host ""
 
         $trashItems = Get-WinOpsTrashList
@@ -505,9 +505,9 @@ function Get-TrashItems {
         Import-Module $trashModule -Force
 
         Write-Host ""
-        Write-Host "╔══════════════════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-        Write-Host "║                          $(Get-WinOpsMessage -Key 'Trash_Title')                                     ║" -ForegroundColor Cyan
-        Write-Host "╚══════════════════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
+        Write-Host "|                          $(Get-WinOpsMessage -Key 'Trash_Title')                                     |" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
         Write-Host ""
 
         $items = Get-WinOpsTrashList
@@ -526,7 +526,7 @@ function Get-TrashItems {
 
         # Display items in a table format
         Write-Host ("{0,-12} {1,-20} {2,-10} {3,-12} {4}" -f "Hash", "Module", "Size (MB)", "Expires In", "Original Path") -ForegroundColor Gray
-        Write-Host ("{0,-12} {1,-20} {2,-10} {3,-12} {4}" -f "────", "──────", "─────────", "──────────", "─────────────") -ForegroundColor DarkGray
+        Write-Host ("{0,-12} {1,-20} {2,-10} {3,-12} {4}" -f "----", "------", "---------", "----------", "-------------") -ForegroundColor DarkGray
 
         foreach ($item in $items) {
             $hashShort = $item.Hash.Substring(0, 12)
@@ -576,9 +576,9 @@ function Restore-TrashItem {
         Import-Module $trashModule -Force
 
         Write-Host ""
-        Write-Host "╔══════════════════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-        Write-Host "║                       $(Get-WinOpsMessage -Key 'Restore_Title')                                 ║" -ForegroundColor Cyan
-        Write-Host "╚══════════════════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
+        Write-Host "|                       $(Get-WinOpsMessage -Key 'Restore_Title')                                 |" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
         Write-Host ""
 
         $items = Get-WinOpsTrashList
@@ -660,9 +660,9 @@ function Install-WinOps {
 
     try {
         Write-Host ""
-        Write-Host "╔══════════════════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-        Write-Host "║                      $(Get-WinOpsMessage -Key 'Install_Title')                                     ║" -ForegroundColor Cyan
-        Write-Host "╚══════════════════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
+        Write-Host "|                      $(Get-WinOpsMessage -Key 'Install_Title')                                     |" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
         Write-Host ""
 
         # Check for admin privileges
@@ -710,9 +710,9 @@ function Uninstall-WinOps {
 
     try {
         Write-Host ""
-        Write-Host "╔══════════════════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-        Write-Host "║                     $(Get-WinOpsMessage -Key 'Uninstall_Title')                                    ║" -ForegroundColor Cyan
-        Write-Host "╚══════════════════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
+        Write-Host "|                     $(Get-WinOpsMessage -Key 'Uninstall_Title')                                    |" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
         Write-Host ""
 
         # Check for admin privileges

--- a/install.ps1
+++ b/install.ps1
@@ -167,9 +167,9 @@ function Add-WinOpsToPath {
 #region Installation Steps
 
 Write-Host ""
-Write-Host "╔════════════════════════════════════════╗" -ForegroundColor Cyan
-Write-Host "║      Win-Ops Installation Script      ║" -ForegroundColor Cyan
-Write-Host "╚════════════════════════════════════════╝" -ForegroundColor Cyan
+Write-Host "+========================================+" -ForegroundColor Cyan
+Write-Host "|      Win-Ops Installation Script      |" -ForegroundColor Cyan
+Write-Host "+========================================+" -ForegroundColor Cyan
 Write-Host ""
 
 # Step 1: Check PowerShell version
@@ -344,9 +344,9 @@ if ($InstallScheduledTask) {
 #region Summary
 
 Write-Host ""
-Write-Host "╔════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║     Installation Complete! ✓          ║" -ForegroundColor Green
-Write-Host "╚════════════════════════════════════════╝" -ForegroundColor Green
+Write-Host "+========================================+" -ForegroundColor Green
+Write-Host "|     Installation Complete!            |" -ForegroundColor Green
+Write-Host "+========================================+" -ForegroundColor Green
 Write-Host ""
 
 Write-Host "Installation Summary:" -ForegroundColor Cyan

--- a/lib/core/I18n.psm1
+++ b/lib/core/I18n.psm1
@@ -15,6 +15,27 @@ $script:I18nConfig = @{
 
 #region Private Functions
 
+function ConvertTo-HashtableFromJson {
+    <#
+    .SYNOPSIS
+        Converts a JSON string to a hashtable (PS 5.1 compatible).
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [string]$JsonString
+    )
+    process {
+        $obj = $JsonString | ConvertFrom-Json
+        $hash = @{}
+        $obj.PSObject.Properties | ForEach-Object {
+            $hash[$_.Name] = $_.Value
+        }
+        return $hash
+    }
+}
+
 function Get-SystemLanguage {
     <#
     .SYNOPSIS
@@ -72,8 +93,12 @@ function Load-LanguageResources {
     }
 
     try {
-        $jsonContent = Get-Content -Path $resourceFile -Raw -ErrorAction Stop
-        $data = $jsonContent | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+        $jsonContent = Get-Content -Path $resourceFile -Raw -Encoding UTF8 -ErrorAction Stop
+        $obj = ConvertFrom-Json -InputObject $jsonContent -ErrorAction Stop
+        $data = @{}
+        foreach ($prop in $obj.PSObject.Properties) {
+            $data[$prop.Name] = $prop.Value
+        }
         Write-Verbose "Loaded language resources: $Language ($($data.Count) messages)"
         return $data
     }

--- a/lib/core/Trash.psm1
+++ b/lib/core/Trash.psm1
@@ -12,6 +12,28 @@ $script:IndexLock = $null
 
 #region Private Functions
 
+function ConvertTo-HashtableRecursive {
+    <#
+    .SYNOPSIS
+        Recursively converts PSCustomObject to hashtable (PS 5.1 compatible).
+    #>
+    param($Object)
+
+    if ($null -eq $Object) { return $null }
+    if ($Object -is [System.Collections.IDictionary]) { return $Object }
+    if ($Object -is [PSCustomObject]) {
+        $hash = @{}
+        $Object.PSObject.Properties | ForEach-Object {
+            $hash[$_.Name] = ConvertTo-HashtableRecursive $_.Value
+        }
+        return $hash
+    }
+    if ($Object -is [System.Collections.IEnumerable] -and $Object -isnot [string]) {
+        return @($Object | ForEach-Object { ConvertTo-HashtableRecursive $_ })
+    }
+    return $Object
+}
+
 function Initialize-TrashDirectory {
     [CmdletBinding()]
     param()
@@ -100,7 +122,7 @@ function Read-TrashIndex {
 
     try {
         $content = Get-Content -Path $script:IndexFile -Raw -Encoding UTF8 -ErrorAction Stop
-        $index = $content | ConvertFrom-Json -AsHashtable
+        $index = ConvertTo-HashtableRecursive ($content | ConvertFrom-Json)
 
         if (-not $index.ContainsKey('items')) {
             $index['items'] = @{}

--- a/lib/modules/Analyze.psm1
+++ b/lib/modules/Analyze.psm1
@@ -24,22 +24,22 @@ using namespace System.Collections.Generic
 # Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
 if (-not (Get-Command Get-WinOpsConfig -ErrorAction SilentlyContinue)) {
-    Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force
+    Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force -Global
 }
 if (-not (Get-Command Initialize-WinOpsLogger -ErrorAction SilentlyContinue)) {
-    Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force
+    Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force -Global
 }
 
 # Import format module for visual output
 $utilsModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\utils'
 if ((Test-Path (Join-Path $utilsModulePath 'Format.psm1')) -and -not (Get-Command Format-WinOpsSize -ErrorAction SilentlyContinue)) {
-    Import-Module (Join-Path $utilsModulePath 'Format.psm1') -Force -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $utilsModulePath 'Format.psm1') -Force -Global -ErrorAction SilentlyContinue
 }
 
 # Import I18n module
 $i18nModulePath = Join-Path $coreModulePath 'I18n.psm1'
 if ((Test-Path $i18nModulePath) -and -not (Get-Command Get-WinOpsMessage -ErrorAction SilentlyContinue)) {
-    Import-Module $i18nModulePath -Force -ErrorAction SilentlyContinue
+    Import-Module $i18nModulePath -Force -Global -ErrorAction SilentlyContinue
     Initialize-WinOpsI18n -ErrorAction SilentlyContinue
 }
 
@@ -134,7 +134,7 @@ function Import-CleanupModule {
     }
 
     try {
-        Import-Module $modulePath -Force -ErrorAction Stop
+        Import-Module $modulePath -Force -Global -ErrorAction Stop
         return $true
     }
     catch {
@@ -314,7 +314,7 @@ function Format-SizeBar {
     $percentage = $Value / $MaxValue
     $filledWidth = [math]::Floor($percentage * $Width)
 
-    $bar = "█" * $filledWidth + "░" * ($Width - $filledWidth)
+    $bar = "#" * $filledWidth + " " * ($Width - $filledWidth)
 
     return $bar
 }
@@ -501,9 +501,9 @@ function Get-WinOpsAnalysis {
             "Win-Ops Cleanup Analysis Report"
         }
         Write-Host ""
-        Write-Host "╔══════════════════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-        Write-Host "║                    $titleMsg                       ║" -ForegroundColor Cyan
-        Write-Host "╚══════════════════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
+        Write-Host "|                    $titleMsg                       |" -ForegroundColor Cyan
+        Write-Host "+==========================================================================+" -ForegroundColor Cyan
         Write-Host ""
 
         $timeLabel = if (Get-Command Get-WinOpsMessage -ErrorAction SilentlyContinue) {
@@ -527,7 +527,7 @@ function Get-WinOpsAnalysis {
         } else {
             "Category Summary"
         }
-        Write-Host "═══ $categorySummaryLabel ═══" -ForegroundColor Cyan
+        Write-Host "=== $categorySummaryLabel ===" -ForegroundColor Cyan
         Write-Host ""
 
         $maxSize = ($categorySummary | Measure-Object -Property TotalSizeGB -Maximum).Maximum
@@ -547,7 +547,7 @@ function Get-WinOpsAnalysis {
         } else {
             "Summary"
         }
-        Write-Host "═══ $summaryLabel ═══" -ForegroundColor Cyan
+        Write-Host "=== $summaryLabel ===" -ForegroundColor Cyan
 
         $reclaimableMsg = if (Get-Command Get-WinOpsMessage -ErrorAction SilentlyContinue) {
             Get-WinOpsMessage -Key 'Analyze_Total_Reclaimable' -Args ("{0:N2}" -f $totalSizeGB), ("{0:N2}" -f $totalSizeMB)
@@ -577,7 +577,7 @@ function Get-WinOpsAnalysis {
         } else {
             "Top $TopN Largest Items"
         }
-        Write-Host "═══ $topItemsLabel ═══" -ForegroundColor Cyan
+        Write-Host "=== $topItemsLabel ===" -ForegroundColor Cyan
         Write-Host ""
 
         $rank = 1
@@ -686,7 +686,7 @@ function Compare-WinOpsAnalysis {
     } else {
         "Cleanup Comparison"
     }
-    Write-Host "═══ $titleMsg ═══" -ForegroundColor Cyan
+    Write-Host "=== $titleMsg ===" -ForegroundColor Cyan
     Write-Host ""
 
     $beforeMsg = if (Get-Command Get-WinOpsMessage -ErrorAction SilentlyContinue) {

--- a/lib/modules/BrowserCleanup.psm1
+++ b/lib/modules/BrowserCleanup.psm1
@@ -23,10 +23,10 @@ using namespace System.IO
 
 # Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
-if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
-if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
-if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force -Global }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force -Global }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force -Global }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force -Global }
 
 #region Browser Definitions
 

--- a/lib/modules/CacheCleanup.psm1
+++ b/lib/modules/CacheCleanup.psm1
@@ -24,15 +24,15 @@ using namespace System.IO
 
 # Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
-if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
-if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
-if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force -Global }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force -Global }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force -Global }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force -Global }
 
 # Import I18n module
 $i18nModulePath = Join-Path $coreModulePath 'I18n.psm1'
 if ((Test-Path $i18nModulePath) -and -not (Get-Command Get-WinOpsMessage -ErrorAction SilentlyContinue)) {
-    Import-Module $i18nModulePath -Force -ErrorAction SilentlyContinue
+    Import-Module $i18nModulePath -Force -Global -ErrorAction SilentlyContinue
     Initialize-WinOpsI18n -ErrorAction SilentlyContinue
 }
 
@@ -164,7 +164,7 @@ function Get-CacheSize {
             $items = Get-ChildItem -Path $expandedPath -Force -ErrorAction SilentlyContinue
         } else {
             # Handle direct paths
-            if (Test-Path $expandedPath) {
+            if (Test-Path $expandedPath -ErrorAction SilentlyContinue) {
                 $items = Get-ChildItem -Path $expandedPath -Recurse -Force -ErrorAction SilentlyContinue
             } else {
                 continue
@@ -331,13 +331,13 @@ function Clear-WinOpsCache {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
     param(
-        [Parameter(Mandatory)]
+        [Parameter()]
         [ValidateSet(
             'WindowsTemp', 'ChromeCache', 'EdgeCache', 'FirefoxCache',
             'WindowsStoreCache', 'ThumbnailCache', 'IconCache', 'FontCache',
             'Prefetch', 'DeliveryOptimization', 'All'
         )]
-        [string]$CacheType,
+        [string]$CacheType = 'All',
 
         [Parameter()]
         [ValidateRange(0, 365)]

--- a/lib/modules/DevCleanup.psm1
+++ b/lib/modules/DevCleanup.psm1
@@ -19,10 +19,10 @@ using namespace System.IO
 
 # Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
-if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
-if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
-if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force -Global }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force -Global }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force -Global }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force -Global }
 
 #region Cache Target Definitions
 

--- a/lib/modules/DockerCleanup.psm1
+++ b/lib/modules/DockerCleanup.psm1
@@ -21,9 +21,9 @@
 
 # Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
-if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
-if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force -Global }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force -Global }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force -Global }
 
 #region Private Functions
 

--- a/lib/modules/LogCleanup.psm1
+++ b/lib/modules/LogCleanup.psm1
@@ -23,10 +23,10 @@ using namespace System.Diagnostics.Eventing.Reader
 
 # Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
-if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
-if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
-if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force -Global }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force -Global }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force -Global }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force -Global }
 
 #region Log Locations
 
@@ -401,9 +401,9 @@ function Clear-WinOpsLogFiles {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject[]])]
     param(
-        [Parameter(Mandatory)]
+        [Parameter()]
         [ValidateSet('WindowsLogs', 'IISLogs', 'ApplicationLogs', 'SetupLogs', 'VSCodeLogs', 'PowerShellLogs', 'All')]
-        [string]$Location,
+        [string]$Location = 'All',
 
         [Parameter()]
         [ValidateRange(0, 365)]

--- a/lib/modules/OrphanAppCleanup.psm1
+++ b/lib/modules/OrphanAppCleanup.psm1
@@ -22,10 +22,10 @@ using namespace System.IO
 
 # Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
-if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
-if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
-if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force -Global }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force -Global }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force -Global }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force -Global }
 
 #region Private Functions
 

--- a/lib/modules/OrphanKiller.psm1
+++ b/lib/modules/OrphanKiller.psm1
@@ -19,9 +19,9 @@
 
 # Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
-if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
-if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force -Global }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force -Global }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force -Global }
 
 #region Private Functions
 

--- a/lib/modules/PackageManagerCleanup.psm1
+++ b/lib/modules/PackageManagerCleanup.psm1
@@ -21,10 +21,10 @@ using namespace System.IO
 
 # Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
-if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
-if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
-if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force -Global }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force -Global }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force -Global }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force -Global }
 
 #region Package Manager Locations
 

--- a/lib/modules/TmpCleanup.psm1
+++ b/lib/modules/TmpCleanup.psm1
@@ -23,10 +23,10 @@ using namespace System.IO
 
 # Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
-if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
-if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
-if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force }
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force -Global }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force -Global }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force -Global }
+if (-not (Get-Module -Name Trash)) { Import-Module (Join-Path $coreModulePath 'Trash.psm1') -Force -Global }
 
 #region Temp Locations
 
@@ -405,13 +405,13 @@ function Clear-WinOpsTempFiles {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject[]])]
     param(
-        [Parameter(Mandatory)]
+        [Parameter()]
         [ValidateSet(
             'UserTemp', 'SystemTemp', 'RecentItems', 'WindowsErrorReporting',
             'MemoryDumps', 'WindowsInstallerCache', 'WindowsUpdateTemp', 'WindowsSetupLogs',
             'DownloadedInstallFiles', 'TempInternetFiles', 'All'
         )]
-        [string]$Location,
+        [string]$Location = 'All',
 
         [Parameter()]
         [ValidateRange(0, 365)]

--- a/lib/modules/ZombieKiller.psm1
+++ b/lib/modules/ZombieKiller.psm1
@@ -19,9 +19,9 @@
 
 # Import required core modules (skip if already loaded to avoid scope conflicts)
 $coreModulePath = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib\core'
-if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force }
-if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force }
-if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force }
+if (-not (Get-Module -Name Config)) { Import-Module (Join-Path $coreModulePath 'Config.psm1') -Force -Global }
+if (-not (Get-Module -Name Logger)) { Import-Module (Join-Path $coreModulePath 'Logger.psm1') -Force -Global }
+if (-not (Get-Module -Name Safety)) { Import-Module (Join-Path $coreModulePath 'Safety.psm1') -Force -Global }
 
 #region Private Functions
 
@@ -305,14 +305,19 @@ function Find-WinOpsZombieProcess {
                 continue
             }
 
+            $startTime = try { $process.StartTime } catch { $null }
+            $cpuPercent = if ($IncludeHighCPU) { Get-ProcessCPUUsage -Process $process } else { 0 }
+            $memoryMB = Get-ProcessMemoryUsageMB -Process $process
+            $responding = Test-ProcessResponding -Process $process
+
             $zombieProcesses += [PSCustomObject]@{
                 ProcessId = $process.Id
                 ProcessName = $process.ProcessName
                 MainWindowTitle = $process.MainWindowTitle
-                StartTime = try { $process.StartTime } catch { $null }
-                CPUPercent = if ($IncludeHighCPU) { Get-ProcessCPUUsage -Process $process } else { 0 }
-                MemoryMB = Get-ProcessMemoryUsageMB -Process $process
-                Responding = Test-ProcessResponding -Process $process
+                StartTime = $startTime
+                CPUPercent = $cpuPercent
+                MemoryMB = $memoryMB
+                Responding = $responding
                 Reasons = $candidate.Reasons -join ", "
             }
         }

--- a/lib/utils/Format.psm1
+++ b/lib/utils/Format.psm1
@@ -301,17 +301,17 @@ function Write-WinOpsSummary {
 
     if ($CleanedCount -gt 0) {
         $formattedSize = Format-WinOpsBytes -Bytes $CleanedBytes
-        Write-WinOpsColor -Text "✓" -Color Green -NoNewline
+        Write-WinOpsColor -Text "OK" -Color Green -NoNewline
         Write-Host " Files cleaned: $CleanedCount items ($formattedSize)"
     }
 
     if ($KilledProcs -gt 0) {
-        Write-WinOpsColor -Text "✓" -Color Green -NoNewline
+        Write-WinOpsColor -Text "OK" -Color Green -NoNewline
         Write-Host " Processes terminated: $KilledProcs items"
     }
 
     if ($CleanedCount -eq 0 -and $KilledProcs -eq 0) {
-        Write-WinOpsColor -Text "ℹ" -Color Blue -NoNewline
+        Write-WinOpsColor -Text "[INFO]" -Color Blue -NoNewline
         Write-Host " No items to clean"
     }
 
@@ -383,16 +383,16 @@ function Write-WinOpsReport {
 
     # Disk usage row
     $diskUsageIndicator = if ($diskUsageDelta -lt 0) {
-        Write-WinOpsColor -Text "↓" -Color Green -NoNewline
-        "↓"
+        Write-WinOpsColor -Text "v" -Color Green -NoNewline
+        "v"
     } elseif ($diskUsageDelta -eq 0) {
         "="
     } else {
-        Write-WinOpsColor -Text "↑" -Color Yellow -NoNewline
-        "↑"
+        Write-WinOpsColor -Text "^" -Color Yellow -NoNewline
+        "^"
     }
 
-    Write-Host ("{0,-12} : {1,6}   →  {2,6}   ({3} {4}%)" -f `
+    Write-Host ("{0,-12} : {1,6}   ->  {2,6}   ({3} {4}%)" -f `
         "Disk", `
         "$($BeforeSnapshot.DiskUsagePct)%", `
         "$($AfterSnapshot.DiskUsagePct)%", `
@@ -401,16 +401,16 @@ function Write-WinOpsReport {
 
     # Disk free row
     $diskFreeIndicator = if ($diskFreeDelta -gt 0) {
-        Write-WinOpsColor -Text "↑" -Color Green -NoNewline
-        "↑"
+        Write-WinOpsColor -Text "^" -Color Green -NoNewline
+        "^"
     } elseif ($diskFreeDelta -eq 0) {
         "="
     } else {
-        Write-WinOpsColor -Text "↓" -Color Yellow -NoNewline
-        "↓"
+        Write-WinOpsColor -Text "v" -Color Yellow -NoNewline
+        "v"
     }
 
-    Write-Host ("{0,-12} : {1,9} →  {2,9} ({3} {4})" -f `
+    Write-Host ("{0,-12} : {1,9} ->  {2,9} ({3} {4})" -f `
         "Disk Free", `
         $beforeDiskFree, `
         $afterDiskFree, `
@@ -419,16 +419,16 @@ function Write-WinOpsReport {
 
     # Memory used row
     $memUsedIndicator = if ($memUsedDelta -lt 0) {
-        Write-WinOpsColor -Text "↓" -Color Green -NoNewline
-        "↓"
+        Write-WinOpsColor -Text "v" -Color Green -NoNewline
+        "v"
     } elseif ($memUsedDelta -eq 0) {
         "="
     } else {
-        Write-WinOpsColor -Text "↑" -Color Yellow -NoNewline
-        "↑"
+        Write-WinOpsColor -Text "^" -Color Yellow -NoNewline
+        "^"
     }
 
-    Write-Host ("{0,-12} : {1,9} →  {2,9} ({3} {4})" -f `
+    Write-Host ("{0,-12} : {1,9} ->  {2,9} ({3} {4})" -f `
         "Memory", `
         $beforeMemUsed, `
         $afterMemUsed, `
@@ -441,17 +441,17 @@ function Write-WinOpsReport {
     $formattedSize = Format-WinOpsBytes -Bytes $CleanedBytes
 
     if ($CleanedCount -gt 0) {
-        Write-WinOpsColor -Text "✓" -Color Green -NoNewline
+        Write-WinOpsColor -Text "OK" -Color Green -NoNewline
         Write-Host " Files cleaned: $CleanedCount items ($formattedSize)"
     }
 
     if ($KilledProcs -gt 0) {
-        Write-WinOpsColor -Text "✓" -Color Green -NoNewline
+        Write-WinOpsColor -Text "OK" -Color Green -NoNewline
         Write-Host " Processes terminated: $KilledProcs items"
     }
 
     if ($CleanedCount -eq 0 -and $KilledProcs -eq 0) {
-        Write-WinOpsColor -Text "ℹ" -Color Blue -NoNewline
+        Write-WinOpsColor -Text "[INFO]" -Color Blue -NoNewline
         Write-Host " No items to clean"
     }
 

--- a/lib/utils/Notify.psm1
+++ b/lib/utils/Notify.psm1
@@ -240,9 +240,9 @@ function Send-FallbackNotification {
 
     # Final fallback: console output only
     $symbol = switch ($Type) {
-        'Success' { '[✓]' }
+        'Success' { '[OK]' }
         'Warning' { '[!]' }
-        'Error'   { '[✗]' }
+        'Error'   { '[FAIL]' }
         'Info'    { '[i]' }
     }
 

--- a/lib/utils/Snapshot.psm1
+++ b/lib/utils/Snapshot.psm1
@@ -9,6 +9,28 @@ $script:CimSession = $null
 
 #region Private Functions
 
+function ConvertTo-HashtableRecursive {
+    <#
+    .SYNOPSIS
+        Recursively converts PSCustomObject to hashtable (PS 5.1 compatible).
+    #>
+    param($Object)
+
+    if ($null -eq $Object) { return $null }
+    if ($Object -is [System.Collections.IDictionary]) { return $Object }
+    if ($Object -is [PSCustomObject]) {
+        $hash = @{}
+        $Object.PSObject.Properties | ForEach-Object {
+            $hash[$_.Name] = ConvertTo-HashtableRecursive $_.Value
+        }
+        return $hash
+    }
+    if ($Object -is [System.Collections.IEnumerable] -and $Object -isnot [string]) {
+        return @($Object | ForEach-Object { ConvertTo-HashtableRecursive $_ })
+    }
+    return $Object
+}
+
 function Initialize-CimSession {
     <#
     .SYNOPSIS
@@ -577,7 +599,7 @@ function Import-WinOpsSnapshot {
         }
 
         $json = Get-Content -Path $Path -Raw -Encoding UTF8
-        $snapshot = $json | ConvertFrom-Json -AsHashtable
+        $snapshot = ConvertTo-HashtableRecursive ($json | ConvertFrom-Json)
 
         Write-Verbose "Snapshot imported from: $Path"
         return $snapshot

--- a/scripts/Verify-I18n.ps1
+++ b/scripts/Verify-I18n.ps1
@@ -28,7 +28,7 @@ function Write-Check {
         [bool]$Success
     )
 
-    $icon = if ($Success) { '✓' } else { '✗' }
+    $icon = if ($Success) { 'OK' } else { 'FAIL' }
     $color = if ($Success) { $SuccessColor } else { $ErrorColor }
 
     Write-Host "$icon " -ForegroundColor $color -NoNewline
@@ -37,14 +37,14 @@ function Write-Check {
 
 function Write-Info {
     param([string]$Message)
-    Write-Host "ℹ " -ForegroundColor $InfoColor -NoNewline
+    Write-Host "[INFO] " -ForegroundColor $InfoColor -NoNewline
     Write-Host $Message
 }
 
 Write-Host ""
-Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-Write-Host "║         Win-Ops i18n Implementation Verification         ║" -ForegroundColor Cyan
-Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+Write-Host "+===========================================================+" -ForegroundColor Cyan
+Write-Host "|         Win-Ops i18n Implementation Verification         |" -ForegroundColor Cyan
+Write-Host "+===========================================================+" -ForegroundColor Cyan
 Write-Host ""
 
 $projectRoot = Split-Path $PSScriptRoot -Parent
@@ -263,9 +263,9 @@ if ($exists) { $passed++ } else { $failed++ }
 
 # Summary
 Write-Host ""
-Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host "===========================================================" -ForegroundColor Cyan
 Write-Host "VERIFICATION SUMMARY" -ForegroundColor Cyan
-Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host "===========================================================" -ForegroundColor Cyan
 Write-Host ""
 
 $total = $passed + $failed
@@ -281,9 +281,9 @@ Write-Host "$percentage%" -ForegroundColor $(if ($percentage -eq 100) { $Success
 Write-Host ""
 
 if ($failed -eq 0) {
-    Write-Host "✓ All checks passed! i18n implementation is complete." -ForegroundColor $SuccessColor
+    Write-Host "OK All checks passed! i18n implementation is complete." -ForegroundColor $SuccessColor
     exit 0
 } else {
-    Write-Host "✗ Some checks failed. Please review the errors above." -ForegroundColor $ErrorColor
+    Write-Host "FAIL Some checks failed. Please review the errors above." -ForegroundColor $ErrorColor
     exit 1
 }

--- a/tests/Core/Trash.Tests.ps1
+++ b/tests/Core/Trash.Tests.ps1
@@ -362,7 +362,13 @@ Describe "Trash Module - Remove-WinOpsExpiredTrash" {
         # Manually edit index to make it expired
         $trashRoot = Join-Path $env:LOCALAPPDATA "win-ops\trash"
         $indexPath = Join-Path $trashRoot ".index.json"
-        $index = Get-Content $indexPath -Raw | ConvertFrom-Json -AsHashtable
+        $indexJson = Get-Content $indexPath -Raw | ConvertFrom-Json
+        $index = @{ items = @{} }
+        $indexJson.items.PSObject.Properties | ForEach-Object {
+            $entry = @{}
+            $_.Value.PSObject.Properties | ForEach-Object { $entry[$_.Name] = $_.Value }
+            $index.items[$_.Name] = $entry
+        }
 
         $expiredTime = (Get-Date).AddHours(-73).ToString("o")
         $index.items[$trash.Hash].deleted_at = $expiredTime

--- a/tests/I18n.Tests.ps1
+++ b/tests/I18n.Tests.ps1
@@ -126,8 +126,8 @@ Describe 'I18n Module' {
             $enFile = Join-Path $projectRoot 'resources\en-US.json'
             $koFile = Join-Path $projectRoot 'resources\ko-KR.json'
 
-            $enData = Get-Content -Path $enFile -Raw | ConvertFrom-Json -AsHashtable
-            $koData = Get-Content -Path $koFile -Raw | ConvertFrom-Json -AsHashtable
+            $enData = Get-Content -Path $enFile -Raw | ConvertFrom-Json | ForEach-Object { $h = @{}; $_.PSObject.Properties | ForEach-Object { $h[$_.Name] = $_.Value }; $h }
+            $koData = Get-Content -Path $koFile -Raw | ConvertFrom-Json | ForEach-Object { $h = @{}; $_.PSObject.Properties | ForEach-Object { $h[$_.Name] = $_.Value }; $h }
 
             $enKeys = $enData.Keys | Sort-Object
             $koKeys = $koData.Keys | Sort-Object

--- a/tests/Integration/E2E.Tests.ps1
+++ b/tests/Integration/E2E.Tests.ps1
@@ -274,7 +274,7 @@ Describe "E2E: Analyze Flow" {
                 }
             }
 
-            # Total should be approximately 50MB + 100KB + 20MB + 5MB ≈ 75MB
+            # Total should be approximately 50MB + 100KB + 20MB + 5MB ~ 75MB
             $report.TotalSize | Should -BeGreaterThan 70MB
             $report.TotalSize | Should -BeLessThan 80MB
 

--- a/tests/Modules/Analyze.Tests.ps1
+++ b/tests/Modules/Analyze.Tests.ps1
@@ -350,7 +350,7 @@ Describe 'Analyze Integration Tests' -Tag 'Integration', 'Module' {
             $barLength = 50
 
             $filledLength = [math]::Floor(($currentValue / $maxValue) * $barLength)
-            $bar = '█' * $filledLength + '░' * ($barLength - $filledLength)
+            $bar = '#' * $filledLength + ' ' * ($barLength - $filledLength)
 
             $bar.Length | Should -Be $barLength
             $filledLength | Should -BeGreaterThan 30

--- a/tests/Run-ModuleTests.ps1
+++ b/tests/Run-ModuleTests.ps1
@@ -185,7 +185,7 @@ if ($Coverage -and $results.CodeCoverage) {
 if ($results.FailedCount -gt 0) {
     Write-Host "`n=== Failed Tests ===" -ForegroundColor Red
     foreach ($test in $results.Failed) {
-        Write-Host "`n❌ $($test.ExpandedName)" -ForegroundColor Red
+        Write-Host "`n[FAIL] $($test.ExpandedName)" -ForegroundColor Red
         Write-Host "   Location: $($test.ScriptBlock.File):$($test.ScriptBlock.StartPosition.StartLine)" -ForegroundColor Gray
         if ($test.ErrorRecord) {
             Write-Host "   Error: $($test.ErrorRecord.Exception.Message)" -ForegroundColor Red

--- a/tests/Validate-Tests.ps1
+++ b/tests/Validate-Tests.ps1
@@ -54,11 +54,11 @@ foreach ($testFile in $testFiles) {
             [ref]$null
         )
         $validation.SyntaxValid = $true
-        Write-Host "  ✓ Syntax valid" -ForegroundColor Green
+        Write-Host "  OK Syntax valid" -ForegroundColor Green
     }
     catch {
         $validation.Errors += "Syntax error: $_"
-        Write-Host "  ✗ Syntax error: $_" -ForegroundColor Red
+        Write-Host "  FAIL Syntax error: $_" -ForegroundColor Red
     }
 
     # Read content
@@ -67,29 +67,29 @@ foreach ($testFile in $testFiles) {
     # Check for BeforeAll
     if ($content -match 'BeforeAll\s*\{') {
         $validation.HasBeforeAll = $true
-        Write-Host "  ✓ Has BeforeAll block" -ForegroundColor Green
+        Write-Host "  OK Has BeforeAll block" -ForegroundColor Green
     }
     else {
         $validation.Warnings += "Missing BeforeAll block"
-        Write-Host "  ⚠ Missing BeforeAll block" -ForegroundColor Yellow
+        Write-Host "  [WARN] Missing BeforeAll block" -ForegroundColor Yellow
     }
 
     # Check for Describe blocks
     $describeMatches = [regex]::Matches($content, "Describe\s+'[^']+'")
     if ($describeMatches.Count -gt 0) {
         $validation.HasDescribe = $true
-        Write-Host "  ✓ Has $($describeMatches.Count) Describe block(s)" -ForegroundColor Green
+        Write-Host "  OK Has $($describeMatches.Count) Describe block(s)" -ForegroundColor Green
     }
     else {
         $validation.Errors += "No Describe blocks found"
-        Write-Host "  ✗ No Describe blocks found" -ForegroundColor Red
+        Write-Host "  FAIL No Describe blocks found" -ForegroundColor Red
     }
 
     # Check for Context blocks
     $contextMatches = [regex]::Matches($content, "Context\s+'[^']+'")
     if ($contextMatches.Count -gt 0) {
         $validation.HasContext = $true
-        Write-Host "  ✓ Has $($contextMatches.Count) Context block(s)" -ForegroundColor Green
+        Write-Host "  OK Has $($contextMatches.Count) Context block(s)" -ForegroundColor Green
     }
 
     # Check for It blocks (tests)
@@ -97,38 +97,38 @@ foreach ($testFile in $testFiles) {
     if ($itMatches.Count -gt 0) {
         $validation.HasIt = $true
         $validation.TestCount = $itMatches.Count
-        Write-Host "  ✓ Has $($itMatches.Count) test(s)" -ForegroundColor Green
+        Write-Host "  OK Has $($itMatches.Count) test(s)" -ForegroundColor Green
     }
     else {
         $validation.Errors += "No tests (It blocks) found"
-        Write-Host "  ✗ No tests (It blocks) found" -ForegroundColor Red
+        Write-Host "  FAIL No tests (It blocks) found" -ForegroundColor Red
     }
 
     # Check for Mock declarations
     $mockMatches = [regex]::Matches($content, "Mock\s+[\w-]+")
     $validation.MockCount = $mockMatches.Count
     if ($mockMatches.Count -gt 0) {
-        Write-Host "  ✓ Has $($mockMatches.Count) mock(s)" -ForegroundColor Green
+        Write-Host "  OK Has $($mockMatches.Count) mock(s)" -ForegroundColor Green
     }
 
     # Check for Should -Invoke
     $shouldInvokeMatches = [regex]::Matches($content, "Should\s+-Invoke")
     if ($shouldInvokeMatches.Count -gt 0) {
-        Write-Host "  ✓ Has $($shouldInvokeMatches.Count) mock verification(s)" -ForegroundColor Green
+        Write-Host "  OK Has $($shouldInvokeMatches.Count) mock verification(s)" -ForegroundColor Green
     }
 
     # Check for DryRun tests
     if ($content -match "DryRun") {
-        Write-Host "  ✓ Has DryRun mode tests" -ForegroundColor Green
+        Write-Host "  OK Has DryRun mode tests" -ForegroundColor Green
     }
     else {
         $validation.Warnings += "No DryRun mode tests"
-        Write-Host "  ⚠ No DryRun mode tests" -ForegroundColor Yellow
+        Write-Host "  [WARN] No DryRun mode tests" -ForegroundColor Yellow
     }
 
     # Check for Integration tests
     if ($content -match "Integration") {
-        Write-Host "  ✓ Has Integration tests" -ForegroundColor Green
+        Write-Host "  OK Has Integration tests" -ForegroundColor Green
     }
 
     $validationResults += $validation
@@ -157,7 +157,7 @@ if ($filesWithErrors -gt 0) {
     foreach ($result in $validationResults | Where-Object { $_.Errors.Count -gt 0 }) {
         Write-Host "`n$($result.File):" -ForegroundColor Red
         foreach ($error in $result.Errors) {
-            Write-Host "  • $error" -ForegroundColor Red
+            Write-Host "  * $error" -ForegroundColor Red
         }
     }
 }
@@ -168,7 +168,7 @@ if ($filesWithWarnings -gt 0) {
     foreach ($result in $validationResults | Where-Object { $_.Warnings.Count -gt 0 }) {
         Write-Host "`n$($result.File):" -ForegroundColor Yellow
         foreach ($warning in $result.Warnings) {
-            Write-Host "  • $warning" -ForegroundColor Yellow
+            Write-Host "  * $warning" -ForegroundColor Yellow
         }
     }
 }
@@ -177,9 +177,9 @@ if ($filesWithWarnings -gt 0) {
 Write-Host "`n=== Test Statistics ===" -ForegroundColor Cyan
 $validationResults |
     Select-Object File, TestCount, MockCount, @{N='Status';E={
-        if ($_.Errors.Count -gt 0) { '❌ Error' }
-        elseif ($_.Warnings.Count -gt 0) { '⚠️  Warning' }
-        else { '✅ Valid' }
+        if ($_.Errors.Count -gt 0) { '[FAIL] Error' }
+        elseif ($_.Warnings.Count -gt 0) { '[WARN]  Warning' }
+        else { '[OK] Valid' }
     }} |
     Format-Table -AutoSize |
     Out-String |

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -129,9 +129,9 @@ function Remove-WinOpsFromPath {
 #region Uninstallation Steps
 
 Write-Host ""
-Write-Host "╔════════════════════════════════════════╗" -ForegroundColor Red
-Write-Host "║    Win-Ops Uninstallation Script      ║" -ForegroundColor Red
-Write-Host "╚════════════════════════════════════════╝" -ForegroundColor Red
+Write-Host "+========================================+" -ForegroundColor Red
+Write-Host "|    Win-Ops Uninstallation Script      |" -ForegroundColor Red
+Write-Host "+========================================+" -ForegroundColor Red
 Write-Host ""
 
 # Confirmation prompt
@@ -291,9 +291,9 @@ if (Test-Path $parentDir) {
 #region Summary
 
 Write-Host ""
-Write-Host "╔════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║    Uninstallation Complete! ✓          ║" -ForegroundColor Green
-Write-Host "╚════════════════════════════════════════╝" -ForegroundColor Green
+Write-Host "+========================================+" -ForegroundColor Green
+Write-Host "|    Uninstallation Complete! OK          |" -ForegroundColor Green
+Write-Host "+========================================+" -ForegroundColor Green
 Write-Host ""
 
 Write-Host "Uninstallation Summary:" -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- Add `-Global` flag to all nested `Import-Module -Force` calls to fix module scope conflicts causing `Get-WinOpsConfig` not found errors on PS 5.1
- Replace PS 7+ only features (`ConvertFrom-Json -AsHashtable`, `try/catch` expressions, emoji/Unicode chars) with PS 5.1 compatible alternatives
- Change cleanup function mandatory parameters to optional with defaults, and lower `#Requires` version to 5.1

## Test plan
- [x] Verified `win-ops run -Force` executes successfully on PowerShell 5.1 (cleaned 126 items, 687.49 MB)
- [x] Verified second run works correctly (cleaned 15 items, 1.01 MB)
- [x] Confirmed all modules load without scope conflicts
- [x] Confirmed ASCII output renders correctly on Korean Windows (CP949)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)