### PR TITLE
Fix placeholder URL in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -369,7 +369,7 @@ if ($AddToPath) {
 }
 
 Write-Host ""
-Write-Host "Documentation: https://github.com/your-org/win-ops" -ForegroundColor Gray
+Write-Host "Documentation: https://github.com/seunggabi/win-ops" -ForegroundColor Gray
 Write-Host ""
 
 #endregion


### PR DESCRIPTION
## Summary
- Replace `your-org` placeholder with `seunggabi` in install.ps1 documentation URL

Closes #10

## Test plan
- [x] Verified install.ps1 now shows correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)