### PR TITLE
Fix OrphanAppCleanup ShouldProcess parameter binding on PS 5.1

### DIFF
--- a/bin/win-ops.ps1
+++ b/bin/win-ops.ps1
@@ -366,6 +366,10 @@ function Start-WinOpsCleanup {
                 'OrphanAppCleanup'
             )
 
+            # Suppress confirmation prompts for all modules (already confirmed at top level)
+            $savedConfirmPreference = $ConfirmPreference
+            $ConfirmPreference = 'None'
+
             foreach ($moduleName in $modulesToRun) {
                 try {
                     $modulePath = Join-Path $script:ScriptRoot "lib\modules\$moduleName.psm1"
@@ -396,6 +400,8 @@ function Start-WinOpsCleanup {
                     Write-Warning (Get-WinOpsMessage -Key 'Cleanup_ModuleFailed' -Args $moduleName, $_)
                 }
             }
+
+            $ConfirmPreference = $savedConfirmPreference
 
             # Display summary
             Write-Host "`n=== Cleanup Summary ===" -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- Use `$ConfirmPreference='None'` scope instead of splatting `Confirm=$false` which caused DataType parameter binding errors on PowerShell 5.1

Closes #12

## Test plan
- [x] `win-ops run --force` runs OrphanAppCleanup without DataType error
- [x] All modules complete without parameter binding issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)