### PR TITLE
fix: read schedule settings from win-ops.json

### DIFF
--- a/bin/win-ops.ps1
+++ b/bin/win-ops.ps1
@@ -1090,19 +1090,17 @@ function Set-WinOpsSchedule {
             return
         }
 
-        # Load config to read schedule section
-        $configModule = Join-Path $script:ScriptRoot 'lib\core\Config.psm1'
-        if (Test-Path $configModule) {
-            Import-Module $configModule -Force
-        }
-
-        $config = Get-WinOpsConfig
+        # Read schedule settings from config/win-ops.json
         $interval = 'Hourly'
         $startTime = $null
 
-        if ($config -and $config.schedule) {
-            if ($config.schedule.interval) { $interval = $config.schedule.interval }
-            if ($config.schedule.startTime) { $startTime = $config.schedule.startTime }
+        $winOpsJsonPath = Join-Path $script:ScriptRoot 'config\win-ops.json'
+        if (Test-Path $winOpsJsonPath) {
+            $rawConfig = Get-Content $winOpsJsonPath -Raw | ConvertFrom-Json
+            if ($rawConfig.schedule) {
+                if ($rawConfig.schedule.interval) { $interval = $rawConfig.schedule.interval }
+                if ($rawConfig.schedule.startTime) { $startTime = $rawConfig.schedule.startTime }
+            }
         }
 
         # Import TaskScheduler module


### PR DESCRIPTION
## Summary

- Fix `win-ops schedule` failing with "property 'schedule' cannot be found" error
- Read schedule settings directly from `config/win-ops.json` instead of `Get-WinOpsConfig`

## Test plan

- [x] `win-ops schedule` reads config and registers task successfully
- [x] Interval and startTime correctly applied from config

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)