### PR TITLE
(#36) fix: resolve Lock path, empty settings, and snapshot property errors in scheduler

### DIFF
--- a/config/win-ops.json
+++ b/config/win-ops.json
@@ -114,37 +114,17 @@
     {
       "name": "MemoryCleanup",
       "enabled": true,
-      "settings": {
-        "minWorkingSetMB": 50,
-        "minIdleMinutes": 10
-      }
+      "settings": {}
     },
     {
       "name": "HistoryCleanup",
       "enabled": true,
-      "settings": {
-        "clearRunDialog": true,
-        "clearExplorerPaths": true,
-        "clearExplorerSearch": true,
-        "clearJumpLists": true,
-        "clearRecentDocs": true,
-        "clearActivityTimeline": true,
-        "clearClipboard": true,
-        "clearShellHistory": true,
-        "clearWindowsSearch": true
-      }
+      "settings": {}
     },
     {
       "name": "RegistryCleanup",
       "enabled": true,
-      "settings": {
-        "backupBeforeDelete": true,
-        "cleanUninstallEntries": true,
-        "cleanSharedDLLs": true,
-        "cleanMUICache": true,
-        "cleanStartupEntries": true,
-        "cleanAppPaths": true
-      }
+      "settings": {}
     }
   ],
 

--- a/lib/core/Lock.psm1
+++ b/lib/core/Lock.psm1
@@ -103,7 +103,7 @@ function Lock-WinOps {
             }
 
             # Write metadata to file
-            $metadata | ConvertTo-Json -Depth 3 | Set-Content -Path Get-LockMetadataPath -Force
+            $metadata | ConvertTo-Json -Depth 3 | Set-Content -Path (Get-LockMetadataPath) -Force
 
             Write-Verbose "Lock acquired successfully (PID: $PID, Created: $createdNew)"
             return $true
@@ -113,8 +113,8 @@ function Lock-WinOps {
             $mutex.Dispose()
 
             # Show who holds the lock
-            if (Test-Path Get-LockMetadataPath) {
-                $existingLock = Get-Content Get-LockMetadataPath -Raw | ConvertFrom-Json
+            if (Test-Path (Get-LockMetadataPath)) {
+                $existingLock = Get-Content (Get-LockMetadataPath) -Raw | ConvertFrom-Json
                 Write-Warning "Lock held by PID $($existingLock.PID) on $($existingLock.Hostname) since $($existingLock.StartTime)"
             }
 
@@ -161,8 +161,8 @@ function Unlock-WinOps {
             $script:LockMutex = $null
 
             # Clean up metadata file
-            if (Test-Path Get-LockMetadataPath) {
-                Remove-Item -Path Get-LockMetadataPath -Force -ErrorAction SilentlyContinue
+            if (Test-Path (Get-LockMetadataPath)) {
+                Remove-Item -Path (Get-LockMetadataPath) -Force -ErrorAction SilentlyContinue
             }
 
             Write-Verbose "Lock released successfully"
@@ -184,8 +184,8 @@ function Unlock-WinOps {
 
         $script:LockMutex = $null
 
-        if (Test-Path Get-LockMetadataPath) {
-            Remove-Item -Path Get-LockMetadataPath -Force -ErrorAction SilentlyContinue
+        if (Test-Path (Get-LockMetadataPath)) {
+            Remove-Item -Path (Get-LockMetadataPath) -Force -ErrorAction SilentlyContinue
         }
     }
 }
@@ -285,13 +285,13 @@ function Clear-WinOpsStaleLock {
     )
 
     try {
-        if (-not (Test-Path Get-LockMetadataPath)) {
+        if (-not (Test-Path (Get-LockMetadataPath))) {
             Write-Verbose "No lock metadata file found"
             return $false
         }
 
         # Read existing lock metadata
-        $lockData = Get-Content Get-LockMetadataPath -Raw | ConvertFrom-Json
+        $lockData = Get-Content (Get-LockMetadataPath) -Raw | ConvertFrom-Json
         $lockPID = $lockData.PID
         $lockStartTime = [DateTime]::Parse($lockData.StartTime)
         $lockAge = (Get-Date) - $lockStartTime
@@ -317,7 +317,7 @@ function Clear-WinOpsStaleLock {
             Write-Warning "Clearing stale lock: $reason"
 
             # Remove metadata file
-            Remove-Item -Path Get-LockMetadataPath -Force -ErrorAction Stop
+            Remove-Item -Path (Get-LockMetadataPath) -Force -ErrorAction Stop
 
             # Try to acquire and release the mutex to clear it
             try {

--- a/scheduler/Invoke-WinOpsScheduled.ps1
+++ b/scheduler/Invoke-WinOpsScheduled.ps1
@@ -126,7 +126,7 @@ try {
                     $params['DryRun'] = $true
                 }
 
-                if ($module.Settings) {
+                if ($module.Settings -and @($module.Settings.PSObject.Properties).Count -gt 0) {
                     foreach ($key in $module.Settings.PSObject.Properties.Name) {
                         $params[$key] = $module.Settings.$key
                     }
@@ -191,7 +191,7 @@ try {
         $snapshotAfter = Get-WinOpsSnapshot -IncludeDisk -IncludeMemory
 
         # Compare snapshots
-        $comparison = Compare-WinOpsSnapshot -Before $snapshotBefore -After $snapshotAfter
+        $comparison = Compare-WinOpsSnapshot -Before $snapshotBefore -After $snapshotAfter -Format Raw
 
         # Generate summary
         $totalFreedGB = [math]::Round($totalFreed / 1GB, 2)
@@ -211,9 +211,9 @@ Total Space Freed: $totalFreedGB GB
 Disk Space Change:
 "@
 
-        if ($comparison.Disks) {
-            foreach ($drive in $comparison.Disks.Keys) {
-                $diskChange = $comparison.Disks[$drive]
+        if ($comparison.Disk) {
+            foreach ($drive in $comparison.Disk.Keys) {
+                $diskChange = $comparison.Disk[$drive]
                 $summary += "`n  $drive - Freed: $($diskChange.FreedGB) GB (Used: $($diskChange.BeforeUsedPercent)% -> $($diskChange.AfterUsedPercent)%)"
             }
         }


### PR DESCRIPTION
## Summary
- Fix `Get-LockMetadataPath` calls missing parentheses in Lock.psm1 — was treated as string literal instead of function call
- Remove non-existent parameter names from MemoryCleanup, HistoryCleanup, RegistryCleanup settings in config
- Add empty settings guard in scheduler to prevent StrictMode error on `.PSObject.Properties.Name`
- Fix `$comparison.Disks` → `$comparison.Disk` (correct property name)
- Pass `-Format Raw` to `Compare-WinOpsSnapshot` so scheduler gets hashtable instead of formatted string

Closes #36

## Test plan
- [x] Scheduled task test run — all 10 modules completed without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)