### PR TITLE
(#38) fix: hide PowerShell window for scheduled task execution

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -316,9 +316,12 @@ if ($AddToPath) {
     Write-InstallMessage "Step 5: Skipping PATH addition (use -AddToPath to enable)" -Type Info
 }
 
-# Step 6: Install scheduled task (optional)
-if ($InstallScheduledTask) {
-    Write-InstallMessage "Step 6: Installing scheduled task..." -Type Info
+# Step 6: Install scheduled task (optional, or auto-update if already installed)
+$taskAlreadyExists = Get-ScheduledTask -TaskName "Win-Ops System Cleanup" -ErrorAction SilentlyContinue
+
+if ($InstallScheduledTask -or $taskAlreadyExists) {
+    $reason = if ($taskAlreadyExists -and -not $InstallScheduledTask) { "updating existing" } else { "installing" }
+    Write-InstallMessage "Step 6: $(if ($taskAlreadyExists -and -not $InstallScheduledTask) { 'Updating existing scheduled task (auto-detected)...' } else { 'Installing scheduled task...' })" -Type Info
 
     if (-not (Test-IsElevated)) {
         Write-InstallMessage "Administrator privileges required for scheduled task installation" -Type Error
@@ -329,9 +332,9 @@ if ($InstallScheduledTask) {
             Import-Module $schedulerModule -Force
 
             Install-WinOpsScheduledTask -Interval $ScheduleInterval -Force
-            Write-InstallMessage "Scheduled task installed successfully" -Type Success
+            Write-InstallMessage "Scheduled task $reason successfully" -Type Success
         } catch {
-            Write-InstallMessage "Failed to install scheduled task: $_" -Type Error
+            Write-InstallMessage "Failed to $reason scheduled task: $_" -Type Error
             Write-InstallMessage "You can install it manually later using: Install-WinOpsScheduledTask" -Type Info
         }
     }

--- a/scheduler/TaskScheduler.psm1
+++ b/scheduler/TaskScheduler.psm1
@@ -150,7 +150,7 @@ function Install-WinOpsScheduledTask {
     # Create task action
     $action = New-ScheduledTaskAction `
         -Execute "pwsh.exe" `
-        -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$scriptPath`"" `
+        -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$scriptPath`"" `
         -WorkingDirectory $workingDir
 
     # Create task trigger based on interval

--- a/scheduler/WinOpsTask.xml
+++ b/scheduler/WinOpsTask.xml
@@ -48,7 +48,7 @@
   <Actions Context="Author">
     <Exec>
       <Command>pwsh.exe</Command>
-      <Arguments>-NoProfile -ExecutionPolicy Bypass -File "SCRIPT_PATH"</Arguments>
+      <Arguments>-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File "SCRIPT_PATH"</Arguments>
       <WorkingDirectory>WORKING_DIR</WorkingDirectory>
     </Exec>
   </Actions>


### PR DESCRIPTION
## Summary
- Add `-WindowStyle Hidden -NonInteractive` to pwsh arguments in `WinOpsTask.xml` and `TaskScheduler.psm1`
- Auto-detect existing scheduled task on reinstall in `install.ps1` — reinstalling without `-InstallScheduledTask` flag now updates the task automatically

## Test plan
- [ ] Register scheduled task and confirm pwsh window does not appear on execution
- [ ] Run `install.ps1` on a machine with an existing task and confirm it auto-updates
- [ ] Run `Install-WinOpsScheduledTask -Force` and verify `Arguments` contains `-WindowStyle Hidden`

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)