### PR TITLE
(#40) docs: add Git install and execution policy bypass to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ win-ops run --force
 ### From source (recommended)
 
 ```powershell
+winget install --id Git.Git -e --source winget
 git clone https://github.com/seunggabi/win-ops.git
 cd win-ops
-.\install.ps1
+PowerShell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
 ### Manual installation


### PR DESCRIPTION
## Summary
- Add `winget install --id Git.Git` step before `git clone` for users without Git installed
- Replace `.\install.ps1` with `PowerShell -ExecutionPolicy Bypass -File .\install.ps1` to handle security policy errors

Closes #40